### PR TITLE
update vinyl to new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cheerio": "^0.15.0",
     "deco": "^0.12.3",
     "event-stream": "^3.1.5",
-    "vinyl": "^0.2.3"
+    "vinyl": "^2.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
New vinyl version adds a property "_isVinyl", and the vinyl dest() method looks for that property to validate it is a true vinyl file. This old version of vinyl doesn't take this property into account so all files piped to dest() throw a non-vinyl object error.